### PR TITLE
Fixing the "useLayoutEffect" warning on SSR

### DIFF
--- a/src/create-container.tsx
+++ b/src/create-container.tsx
@@ -2,7 +2,7 @@ import type { Action, AnyReducer, EmptyDispatcher } from './typings';
 import { splitReducer } from './create-plugin';
 import { storeContext } from './context';
 import React, {
-  useLayoutEffect, useReducer, useMemo,
+  useLayoutEffect, useEffect, useReducer, useMemo,
   ComponentType, FunctionComponent
 } from 'react';
 
@@ -27,7 +27,9 @@ export function createContainer<S, A extends Action>(
 
     const value = useMemo(() => ({ state, dispatch }), [ state ]);
 
-    useLayoutEffect(() => {
+    const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+    useIsomorphicLayoutEffect(() => {
       if (dispatcher) {
         dispatcher.dispatch = dispatch;
       }

--- a/src/create-container.tsx
+++ b/src/create-container.tsx
@@ -15,6 +15,8 @@ type Container<S> = FunctionComponent<{
 
 // ---------------------------------------------------------------------
 
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
 export function createContainer<S, A extends Action>(
   Component: ComponentType<{ store: S }>,
   anyReducer: AnyReducer<S, A>,
@@ -26,8 +28,6 @@ export function createContainer<S, A extends Action>(
     const [ state, dispatch ] = useReducer(reducer, initialState);
 
     const value = useMemo(() => ({ state, dispatch }), [ state ]);
-
-    const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
     useIsomorphicLayoutEffect(() => {
       if (dispatcher) {


### PR DESCRIPTION
Using monarc on any SSR project (e.g. Next.js) results in this error:

`
Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.
`

This is fixed by using conditionally `useLayoutEffect` and `useEffect` based on the presence of the `window` object - if it's there, it is a client environment; Otherwise, it's an SSR environment.